### PR TITLE
Restrict importing of @vue/test-utils in favor of our wrapper

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,5 +20,11 @@ module.exports = {
         "vue"
     ],
     "rules": {
+        "no-restricted-modules": [
+            "error", {
+                "name": "@vue/test-utils",
+                "message": "Please use ./test/utils/test-utils.js instead."
+            }
+        ]
     }
 };

--- a/test/utils/test-utils.js
+++ b/test/utils/test-utils.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-modules */
 import { BootstrapVue } from "bootstrap-vue";
 import { createLocalVue, shallowMount, mount } from "@vue/test-utils";
 import en from "../../i18n/en.json";


### PR DESCRIPTION
Instead of importing `@vue/test-utils`, we should be importing `./test/utils/test-utils.js`. This adds the [`no-restricted-modules` ESLint rule][0] to warn developers not to make this mistake.

`npm test` passes after this change.

[0]: https://eslint.org/docs/rules/no-restricted-modules